### PR TITLE
Discussion about the implementation of xrEnumerateInstanceExtensionProperties and xrEnumerateApiLayerProperties in layers

### DIFF
--- a/openxr-api-layer/pch.h
+++ b/openxr-api-layer/pch.h
@@ -46,6 +46,7 @@
 #include <string>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
Hello @mbucchia and thank you for your excellent template!

I should mention that English is not my native language, so please excuse any spelling or grammatical errors.

When experimenting with different OpenXR API layers I observed a strange behavior regarding their initialization and the functions they implement.
My understanding of the documentation is that the layers should implement both `xrEnumerateInstanceExtensionProperties` and `xrEnumerateApiLayerProperties` even before an XrInstance is created.

The observed behavior is that the layers answer the API calls only with their properties.
- example for `xrEnumerateApiLayerProperties` the returned length is 1 and only the name, version and description of the layer are returned, there is no call to the next function in the chain (so no need for the instance to exist).
- similarly for the `xrEnumerateInstanceExtensionProperties` function, only the extensions implemented by the concerned layer (as specified by the name) are returned. The function call is even returning an XrError if the name parameter doesn't correspond to the layer. There is no call to the next layer either.

Keep in mind I only verified using the `Vive Business Streaming` layers (XR_APILAYER_VIVE_MR and XR_APILAYER_VIVE_facial_tracking). It is possible that other layers may behave differently.

This PR provides an example of the changes I made to follow the layer behavior I described above. The changes are as follows:
- both `xrEnumerateInstanceExtensionProperties` and `xrEnumerateApiLayerProperties` are implemented outside the OpenXrApi to allow their call before any instance creation. Their implementation are heavily inspired by the OpenXR Loader implementation from the official GitHub repo.
- During the instance creation of the layer, there is no more need to create a dummy instance. Using the layer chain, it is possible to query the `xrGetInstanceProcAddr` of each subsequent layer and thus requesting the extensions they implement (assuming they properly implement the `xrEnumerateInstanceExtensionProperties` without requiring an instance). This would fix a "bug" of this template as with the current implementation only the extensions listed by the runtime are available.

My code is not perfect, but I have written it to illustrate my points.

Thank you for your time. I am open to discussing my interpretation of the documentation.
